### PR TITLE
Fix NuGet publish glob matching both packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,9 +81,9 @@ jobs:
           --source https://api.nuget.org/v3/index.json \
           --skip-duplicate
  
-        # Publish main package git (depends on Runtime)
+        # Publish main package (depends on Runtime)
         echo "Publishing SharpAssert (main package)..."
-        dotnet nuget push ./packages/SharpAssert.*.nupkg \
+        dotnet nuget push ./packages/SharpAssert.[0-9]*.nupkg \
           --api-key ${{ secrets.NUGET_API_KEY }} \
           --source https://api.nuget.org/v3/index.json \
           --skip-duplicate


### PR DESCRIPTION
The glob pattern SharpAssert.*.nupkg was matching both the main
package and the Runtime package, causing the publish to fail.
Changed to SharpAssert.[0-9]*.nupkg which only matches packages
starting with a version number, excluding SharpAssert.Runtime.